### PR TITLE
Fix timestamp bug

### DIFF
--- a/vulnerable_asp_net_core/Controllers/SL.cs
+++ b/vulnerable_asp_net_core/Controllers/SL.cs
@@ -348,7 +348,7 @@ namespace vulnerable_asp_net_core.Controllers
 
             string Msg(string msg)
             {
-                return new DateTime() + ":" + msg + "</br>";
+                return DateTime.Now + ":" + msg + "</br>";
             }
 
             if (Request.Query.ContainsKey("showlogs"))


### PR DESCRIPTION
## Summary
- fix timestamp for logged events in InsufficientLogging

## Testing
- `dotnet build vulnerable_asp_net_core/vulnerable_asp_net_core.csproj` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68424d4073948333b15614fa102487b5