### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a vulnerable ASP .net core application that implements all
 vulnerabilities listed in [OWASP's Top 10](https://www.owasp.org/index.php/Category:OWASP_Top_Ten_Project)
 as small web programs. For every web program, we provide an exploit
-int the [exploits subdirectory](./exploits)
+in the [exploits subdirectory](./exploits)
 that documents how the vulnerability can be actually exploited.
 
 # OWASP top 10 (2017)


### PR DESCRIPTION
## Summary
- fix a typo in the README introduction

## Testing
- `dotnet build vulnerable_asp_net_core.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424f2ce49c83338361cfa6725931b4